### PR TITLE
E2E charts correctly generated

### DIFF
--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -1,5 +1,7 @@
 name: Test pull requests
-on: [ pull_request ]
+on: 
+  pull_request:
+    branches: [ main ]
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,8 +2,6 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-    },
+    baseUrl: "http://localhost:8080"
   },
 });

--- a/cypress/e2e/chart-correctly-generated-spec.cy.js
+++ b/cypress/e2e/chart-correctly-generated-spec.cy.js
@@ -1,18 +1,19 @@
 describe("E2E tests for charts being correctly generated...", () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
 
   it("Make sure chart is correctly generated on line page...", () => {
-    cy.visit('/')
-
     cy.findByText("Line").click()
 
     cy.url().should("eq", `${Cypress.config("baseUrl")}/line.html`)
 
-    cy.findByLabelText("Chart title").type("Testing line chart generation")
-    cy.findByLabelText("X label").type("X label")
-    cy.findByLabelText("Y label").type("Y label")
+    cy.addChartTitleAndLabels("Dogs vs. Cats", "Dogs", "Cats")
 
-    cy.findByLabelText("X").type("3")
-    cy.findByLabelText("Y").type("4")
+    cy.addFirstDataPoint("3", "4")
+    cy.addAdditionalDataPoint("5", "6", 1)
+    cy.addAdditionalDataPoint("7", "8", 2)
+    cy.addAdditionalDataPoint("1", "6", 3)
 
     cy.findByRole("button", { name: "Generate chart" }).click()
 
@@ -20,18 +21,16 @@ describe("E2E tests for charts being correctly generated...", () => {
   })
   
   it("Make sure chart is correctly generated on scatter page...", () => {
-    cy.visit('/')
-
     cy.findByText("Scatter").click()
 
     cy.url().should("eq", `${Cypress.config("baseUrl")}/scatter.html`)
 
-    cy.findByLabelText("Chart title").type("Testing scatter chart generation")
-    cy.findByLabelText("X label").type("X label")
-    cy.findByLabelText("Y label").type("Y label")
+    cy.addChartTitleAndLabels("Dogs vs. Cats", "Dogs", "Cats")
 
-    cy.findByLabelText("X").type("3")
-    cy.findByLabelText("Y").type("4")
+    cy.addFirstDataPoint("3", "4")
+    cy.addAdditionalDataPoint("5", "6", 1)
+    cy.addAdditionalDataPoint("7", "8", 2)
+    cy.addAdditionalDataPoint("1", "6", 3)
 
     cy.findByRole("button", { name: "Generate chart" }).click()
 
@@ -39,18 +38,16 @@ describe("E2E tests for charts being correctly generated...", () => {
   })
 
   it("Make sure chart is correctly generated on bar page...", () => {
-    cy.visit('/')
-
     cy.findByText("Bar").click()
 
     cy.url().should("eq", `${Cypress.config("baseUrl")}/bar.html`)
 
-    cy.findByLabelText("Chart title").type("Testing bar chart generation")
-    cy.findByLabelText("X label").type("X label")
-    cy.findByLabelText("Y label").type("Y label")
+    cy.addChartTitleAndLabels("Dogs vs. Cats", "Dogs", "Cats")
 
-    cy.findByLabelText("X").type("3")
-    cy.findByLabelText("Y").type("4")
+    cy.addFirstDataPoint("3", "4")
+    cy.addAdditionalDataPoint("5", "6", 1)
+    cy.addAdditionalDataPoint("7", "8", 2)
+    cy.addAdditionalDataPoint("1", "6", 3)
 
     cy.findByRole("button", { name: "Generate chart" }).click()
 

--- a/cypress/e2e/chart-correctly-generated-spec.cy.js
+++ b/cypress/e2e/chart-correctly-generated-spec.cy.js
@@ -1,0 +1,60 @@
+describe("E2E tests for charts being correctly generated...", () => {
+
+  it("Make sure chart is correctly generated on line page...", () => {
+    cy.visit('/')
+
+    cy.findByText("Line").click()
+
+    cy.url().should("eq", `${Cypress.config("baseUrl")}/line.html`)
+
+    cy.findByLabelText("Chart title").type("Testing line chart generation")
+    cy.findByLabelText("X label").type("X label")
+    cy.findByLabelText("Y label").type("Y label")
+
+    cy.findByLabelText("X").type("3")
+    cy.findByLabelText("Y").type("4")
+
+    cy.findByRole("button", { name: "Generate chart" }).click()
+
+    cy.findByTestId("chart-display").should("not.be.empty")
+  })
+  
+  it("Make sure chart is correctly generated on scatter page...", () => {
+    cy.visit('/')
+
+    cy.findByText("Scatter").click()
+
+    cy.url().should("eq", `${Cypress.config("baseUrl")}/scatter.html`)
+
+    cy.findByLabelText("Chart title").type("Testing scatter chart generation")
+    cy.findByLabelText("X label").type("X label")
+    cy.findByLabelText("Y label").type("Y label")
+
+    cy.findByLabelText("X").type("3")
+    cy.findByLabelText("Y").type("4")
+
+    cy.findByRole("button", { name: "Generate chart" }).click()
+
+    cy.findByTestId("chart-display").should("not.be.empty")
+  })
+
+  it("Make sure chart is correctly generated on bar page...", () => {
+    cy.visit('/')
+
+    cy.findByText("Bar").click()
+
+    cy.url().should("eq", `${Cypress.config("baseUrl")}/bar.html`)
+
+    cy.findByLabelText("Chart title").type("Testing bar chart generation")
+    cy.findByLabelText("X label").type("X label")
+    cy.findByLabelText("Y label").type("Y label")
+
+    cy.findByLabelText("X").type("3")
+    cy.findByLabelText("Y").type("4")
+
+    cy.findByRole("button", { name: "Generate chart" }).click()
+
+    cy.findByTestId("chart-display").should("not.be.empty")
+  })
+
+})

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,5 +1,0 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,5 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+require("@testing-library/cypress/add-commands")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,3 +25,21 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 require("@testing-library/cypress/add-commands")
+
+Cypress.Commands.add("addChartTitleAndLabels", (title, xLabel, yLabel) => {
+  cy.findByLabelText("Chart title").type(title)
+  cy.findByLabelText("X label").type(xLabel)
+  cy.findByLabelText("Y label").type(yLabel)
+})
+
+Cypress.Commands.add("addFirstDataPoint", (x, y) => {
+    cy.findByLabelText("X").type(x)
+    cy.findByLabelText("Y").type(y)
+})
+
+Cypress.Commands.add("addAdditionalDataPoint", (x, y, index) => {
+    cy.findByRole("button", { name: "+" }).click()
+
+    cy.findByTestId(`x-${index}`).type(x)
+    cy.findByTestId(`y-${index}`).type(y)
+})

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+//import './commands'
 
 // Alternatively you can use CommonJS syntax:
-// require('./commands')
+require('./commands')

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "cy:run": "cypress run"
   },
   "devDependencies": {
+    "@testing-library/cypress": "^10.0.1",
     "css-loader": "^6.7.4",
+    "cypress": "^13.6.6",
     "html-webpack-plugin": "^5.5.1",
+    "start-server-and-test": "^2.0.3",
     "style-loader": "^3.3.3",
     "webpack": "^5.83.1",
     "webpack-cli": "^5.1.1",
-    "webpack-dev-server": "^4.15.0",
-    "@testing-library/cypress": "^10.0.1",
-    "cypress": "^13.6.6",
-    "start-server-and-test": "^2.0.3"
+    "webpack-dev-server": "^4.15.0"
   },
   "jest": {
     "moduleNameMapper": {

--- a/src/bar/bar.html
+++ b/src/bar/bar.html
@@ -45,7 +45,7 @@
                             </div>
                             <button id="add-values-btn">+</button>
                         </div>
-                        <div id="chart-display"></div>
+                        <div id="chart-display" data-testid="chart-display"></div>
                     </div>
                 </div>
             </main>

--- a/src/chartBuilder/chartBuilder.js
+++ b/src/chartBuilder/chartBuilder.js
@@ -206,7 +206,7 @@ module.exports = function runChartBuilder(type) {
         const labelElem = document.createElement("label")
         labelElem.classList.add(`${lowerXOrY}-value`)
         const inputType = (type === "bar" && lowerXOrY === "x") ? "" : "type='number'"
-        labelElem.innerHTML = `${upperXOrY} <input ${inputType} class="${lowerXOrY}-value-input" />`
+        labelElem.innerHTML = `${upperXOrY} <input ${inputType} class="${lowerXOrY}-value-input" data-testid="${lowerXOrY}-${xValueInputs.length}"/>`
         return labelElem
     }
 

--- a/src/line/line.html
+++ b/src/line/line.html
@@ -45,7 +45,7 @@
                             </div>
                             <button id="add-values-btn">+</button>
                         </div>
-                        <div id="chart-display"></div>
+                        <div id="chart-display" data-testid="chart-display"></div>
                     </div>
                 </div>
             </main>

--- a/src/scatter/scatter.html
+++ b/src/scatter/scatter.html
@@ -45,7 +45,7 @@
                             </div>
                             <button id="add-values-btn">+</button>
                         </div>
-                        <div id="chart-display"></div>
+                        <div id="chart-display" data-testid="chart-display"></div>
                     </div>
                 </div>
             </main>


### PR DESCRIPTION
- Configured CI to only run tests on pull requests into main not for any branch.
- Added configuration for cypress and e2e tests.
- Added e2e tests for the correct generation of charts on all sub-pages: line, scatter, bar.
- TestIDs were added to allow selection through cypress in all the HTML files: line.html, bar.html, scatter.html. Also added testID's dynamically to additional X Y pairs when the + button is pressed.
- Added cypress commands to allow for repetitive tasks to be simplified, these include:

addChartTitleAndLabels(title: String, xLabel: String, yLabel: String) -> This function adds the title and labels for a given chart.

addFirstDataPoint(x: String | Int, y: String | Int) -> This function must be run before a call to the addAdditionalDataPoint() function and handles adding the first point to a graph. If you only have one point to add this is good.

addAdditionalDataPoint(x: String | Int, y: String | Int, index: String | Int) -> This handles adding additional points after a call to addFirstDataPoint() and uses test ids that are dynamically added through the javascript.